### PR TITLE
Add cache buster on API requests

### DIFF
--- a/api-fetch/__tests__/api-method.test.js
+++ b/api-fetch/__tests__/api-method.test.js
@@ -28,4 +28,13 @@ describe( 'getApiRequest', () => {
 
 		expect( request.url ).toBe( 'redirection/v1/plugin/?_cb=42' );
 	} );
+
+	test( 'preserves caller-provided cache-buster values', () => {
+		Date.now = jest.fn().mockReturnValue( 42 );
+
+		const request = getApiRequest( 'redirection/v1/plugin', { _cb: 99, page: 1 } );
+
+		expect( request.url ).toContain( '_cb=99' );
+		expect( request.url ).not.toContain( '_cb=42' );
+	} );
 } );

--- a/api-fetch/__tests__/api-method.test.js
+++ b/api-fetch/__tests__/api-method.test.js
@@ -1,0 +1,31 @@
+import { getApiRequest } from '../api-method';
+
+describe( 'getApiRequest', () => {
+	const originalDateNow = Date.now;
+
+	afterEach( () => {
+		Date.now = originalDateNow;
+	} );
+
+	test( 'adds no-store cache mode and cache-buster to GET requests', () => {
+		Date.now = jest.fn().mockReturnValue( 1234567890 );
+
+		const request = getApiRequest( 'redirection/v1/redirect', { page: 2, orderby: 'url' } );
+
+		expect( request.cache ).toBe( 'no-store' );
+		expect( request.method ).toBe( 'get' );
+		expect( request.credentials ).toBe( 'include' );
+		expect( request.url ).toContain( 'redirection/v1/redirect/' );
+		expect( request.url ).toContain( 'page=2' );
+		expect( request.url ).toContain( 'orderby=url' );
+		expect( request.url ).toContain( '_cb=1234567890' );
+	} );
+
+	test( 'adds cache-buster when no query params are provided', () => {
+		Date.now = jest.fn().mockReturnValue( 42 );
+
+		const request = getApiRequest( 'redirection/v1/plugin' );
+
+		expect( request.url ).toBe( 'redirection/v1/plugin/?_cb=42' );
+	} );
+} );

--- a/api-fetch/__tests__/index.test.js
+++ b/api-fetch/__tests__/index.test.js
@@ -1,0 +1,23 @@
+import { getActionUrl } from '../index';
+
+describe( 'getActionUrl', () => {
+	test( 'removes cache-buster when it is the first query parameter', () => {
+		expect( getActionUrl( 'redirection/v1/redirect/?_cb=1&foo=bar' ) ).toBe( 'redirection/v1/redirect/?foo=bar' );
+	} );
+
+	test( 'removes wpnonce and cache-buster without leaving broken separators', () => {
+		expect( getActionUrl( 'redirection/v1/redirect/?_wpnonce=abc123&_cb=1&foo=bar' ) ).toBe(
+			'redirection/v1/redirect/?foo=bar'
+		);
+	} );
+
+	test( 'removes the query string entirely when only transient parameters remain', () => {
+		expect( getActionUrl( 'redirection/v1/redirect/?_cb=1' ) ).toBe( 'redirection/v1/redirect/' );
+	} );
+
+	test( 'preserves hashes after removing transient parameters', () => {
+		expect( getActionUrl( 'redirection/v1/redirect/?_cb=1&foo=bar#details' ) ).toBe(
+			'redirection/v1/redirect/?foo=bar#details'
+		);
+	} );
+} );

--- a/api-fetch/api-method.ts
+++ b/api-fetch/api-method.ts
@@ -5,6 +5,7 @@ export type ApiRequest = {
 	url: string;
 	credentials: RequestCredentials;
 	method: string;
+	cache?: RequestCache;
 	redirect?: RequestRedirect;
 	body?: BodyInit | null;
 	[ key: string ]: unknown;
@@ -94,9 +95,10 @@ const postApiheaders = (): Record< string, string > => {
 
 export const getApiRequest = ( path: string, query: ApiQuery = {} ): ApiRequest => ( {
 	headers: getApiHeaders(),
-	url: getRequestString( path, query ),
+	url: getRequestString( path, { ...query, _cb: Date.now() } ),
 	credentials: 'include',
 	method: 'get',
+	cache: 'no-store',
 	redirect: 'error',
 } );
 

--- a/api-fetch/api-method.ts
+++ b/api-fetch/api-method.ts
@@ -95,7 +95,10 @@ const postApiheaders = (): Record< string, string > => {
 
 export const getApiRequest = ( path: string, query: ApiQuery = {} ): ApiRequest => ( {
 	headers: getApiHeaders(),
-	url: getRequestString( path, { ...query, _cb: Date.now() } ),
+	url: getRequestString( path, {
+		...query,
+		_cb: query._cb ?? Date.now(),
+	} ),
 	credentials: 'include',
 	method: 'get',
 	cache: 'no-store',

--- a/api-fetch/index.ts
+++ b/api-fetch/index.ts
@@ -40,11 +40,28 @@ const checkStatus = ( response: Response ) => {
 	throw response;
 };
 
+export function getActionUrl( url: string ) {
+	const hashIndex = url.indexOf( '#' );
+	const hash = hashIndex >= 0 ? url.slice( hashIndex + 1 ) : '';
+	const urlAndQuery = hashIndex >= 0 ? url.slice( 0, hashIndex ) : url;
+	const queryIndex = urlAndQuery.indexOf( '?' );
+
+	if ( queryIndex === -1 ) {
+		return url;
+	}
+
+	const path = urlAndQuery.slice( 0, queryIndex );
+	const query = urlAndQuery.slice( queryIndex + 1 );
+
+	const params = new URLSearchParams( query );
+	params.delete( '_wpnonce' );
+	params.delete( '_cb' );
+
+	return path + ( params.toString() ? '?' + params.toString() : '' ) + ( hash ? '#' + hash : '' );
+}
+
 const recordResponse = ( response: Response, request: ApiFetchOptions ) => {
-	const actionUrl = request.url
-		.replace( /[\?&]_wpnonce=[a-f0-9]*/g, '' )
-		.replace( /[\?&]_cb=[^&]*/g, '' )
-		.replace( /\?$/, '' );
+	const actionUrl = getActionUrl( request.url );
 
 	request.apiFetch = {
 		action: actionUrl + ' ' + request.method.toUpperCase(),

--- a/api-fetch/index.ts
+++ b/api-fetch/index.ts
@@ -41,8 +41,13 @@ const checkStatus = ( response: Response ) => {
 };
 
 const recordResponse = ( response: Response, request: ApiFetchOptions ) => {
+	const actionUrl = request.url
+		.replace( /[\?&]_wpnonce=[a-f0-9]*/g, '' )
+		.replace( /[\?&]_cb=[^&]*/g, '' )
+		.replace( /\?$/, '' );
+
 	request.apiFetch = {
-		action: request.url.replace( /[\?&]_wpnonce=[a-f0-9]*/, '' ) + ' ' + request.method.toUpperCase(),
+		action: actionUrl + ' ' + request.method.toUpperCase(),
 		body: typeof request.body === 'object' ? JSON.stringify( request.body ) : request.body,
 	};
 	request.headers = response.headers as any;


### PR DESCRIPTION
This is an attempt head off any potential caching from aggressive plugins by adding a cache buster to get queries.